### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        context: .
         builder: ${{ steps.buildx.outputs.name }}
         platforms: linux/amd64,linux/arm64,linux/386
         tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: stack --system-ghc test --only-dependencies
 
     - name: Build and Test
-      run: stack --system-ghc test --local-bin-path=./bin
+      run: stack --system-ghc test --copy-bins --local-bin-path=./bin
 
     # Build and Push Docker Image
     - name: Prepare


### PR DESCRIPTION
```
$ docker run --rm --env-file="$HOME/.env" -v `pwd`:/work -w /work ghcr.io/matsubara0507/mdium --publications
Unable to find image 'ghcr.io/matsubara0507/mdium:latest' locally
latest: Pulling from matsubara0507/mdium
35c102085707: Already exists 
251f5509d51d: Already exists 
8e829fe70a46: Already exists 
6001e1789921: Already exists 
60046273647b: Already exists 
caed1d0336c1: Pull complete 
69b5c455ac3a: Pull complete 
5d6e635dc37f: Pull complete 
Digest: sha256:27653f200fed7d6064e88072d8b2f28171735e89d713f167de05cc66000c0e1d
Status: Downloaded newer image for ghcr.io/matsubara0507/mdium:latest
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"mdium\": executable file not found in $PATH": unknown.
```